### PR TITLE
Feature/autoshspe

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ---------------
 
+
+1.0.2 (2023-08-01)
++++++++++++++++++++
+
+- Add `shape.visible` property returns or sets the visibility of the specified object
+
+
 1.0.2 (2023-06-06)
 +++++++++++++++++++
 

--- a/pptx/__init__.py
+++ b/pptx/__init__.py
@@ -2,7 +2,7 @@
 
 """Initialization module for python-pptx package."""
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 import sys

--- a/pptx/oxml/shapes/shared.py
+++ b/pptx/oxml/shapes/shared.py
@@ -168,6 +168,13 @@ class BaseShapeElement(BaseOxmlElement):
         return self._nvXxPr.cNvPr.name
 
     @property
+    def hidden(self):
+        value = self._nvXxPr.cNvPr.get('hidden', None)
+        if value:
+            return XsdBoolean.convert_from_xml(value)
+        return False
+
+    @property
     def txBody(self):
         """
         Child ``<p:txBody>`` element, None if not present

--- a/pptx/shapes/base.py
+++ b/pptx/shapes/base.py
@@ -8,6 +8,7 @@ from pptx.action import ActionSetting
 from pptx.dml.effect import ShadowFormat
 from pptx.shared import ElementProxy
 from pptx.util import lazyproperty
+from pptx.oxml.simpletypes import XsdBoolean
 
 
 class BaseShape(object):
@@ -220,6 +221,18 @@ class BaseShape(object):
     @width.setter
     def width(self, value):
         self._element.cx = value
+
+    @property
+    def visible(self):
+        """
+        Read/write. Returns or sets the visibility of the specified object or the formatting applied
+        to the specified object.
+        """
+        return not self._element.hidden
+
+    @visible.setter
+    def visible(self, value):
+        self._element._nvXxPr.cNvPr.set('hidden', XsdBoolean.convert_to_xml(not value))
 
 
 class _PlaceholderFormat(ElementProxy):


### PR DESCRIPTION
Shape visible(hidden) property
Read/write. Returns or sets the visibility of the specified object.

### Example
```python
presentation.slides[0].shapes[0].visible = True
presentation.slides[0].shapes[1].visible = False

presentation.slides[0].shapes[0].visible = presentation.slides[0].shapes[1].visible
```